### PR TITLE
feat: enable jetstream work queues

### DIFF
--- a/internal/processor/expense/expense.go
+++ b/internal/processor/expense/expense.go
@@ -2,20 +2,20 @@ package expense
 
 import (
 	"context"
-	"time"
+	"fmt"
 
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/nico151999/high-availability-expense-splitter/pkg/db/client"
 	"github.com/nico151999/high-availability-expense-splitter/pkg/environment"
 	"github.com/nico151999/high-availability-expense-splitter/pkg/logging"
-	mqClient "github.com/nico151999/high-availability-expense-splitter/pkg/mq/client"
 	"github.com/nico151999/high-availability-expense-splitter/pkg/mq/processor"
 	"github.com/rotisserie/eris"
 	"github.com/uptrace/bun"
 )
 
 type expenseProcessor struct {
-	natsClient *nats.EncodedConn
+	natsClient *nats.Conn
 	dbClient   bun.IDB
 }
 
@@ -25,7 +25,7 @@ var errPublishExpenseDeleted = eris.New("could not publish expense deleted event
 
 // NewExpenseServer creates a new instance of expense server.
 func NewExpenseProcessor(natsUrl, dbUser, dbPass, dbAddr, db string) (*expenseProcessor, error) {
-	nc, err := mqClient.NewProtoMQClient(natsUrl)
+	nc, err := nats.Connect(natsUrl)
 	if err != nil {
 		return nil, eris.Wrap(err, "failed connecting to NATS server")
 	}
@@ -40,47 +40,61 @@ func (rpProcessor *expenseProcessor) Process(ctx context.Context) error {
 	log := logging.FromContext(ctx).Named("Process")
 	ctx = logging.IntoContext(ctx, log)
 
-	var ccSub *nats.Subscription
+	sourceStreamName := environment.GetExpenseSourceStreamName()
+	groupSourceStreamName := environment.GetGroupSourceStreamName()
+	personSourceStreamName := environment.GetPersonSourceStreamName()
+
+	_, err := processor.CreateOrUpdateSourceStream(
+		ctx,
+		rpProcessor.natsClient,
+		sourceStreamName,
+		fmt.Sprintf("%s.*", environment.GetExpenseSubject("*", "*")),
+	)
+	if err != nil {
+		return err
+	}
+
+	var ecCCtx jetstream.ConsumeContext
 	{
 		eventSubject := environment.GetExpenseCreatedSubject("*", "*")
 		var err error
-		ccSub, err = processor.GetSubjectProcessor(ctx, eventSubject, rpProcessor.natsClient, rpProcessor.expenseCreated)
+		ecCCtx, err = processor.GetStreamProcessor(ctx, rpProcessor.natsClient, sourceStreamName, "EXPENSESPLITTER_EXPENSE_PROCESSOR_EXPENSE_CREATED", eventSubject, rpProcessor.expenseCreated)
 		if err != nil {
 			return eris.Wrapf(err, "an error occurred processing subject %s", eventSubject)
 		}
 	}
-	var cdSub *nats.Subscription
+	var edCCtx jetstream.ConsumeContext
 	{
 		eventSubject := environment.GetExpenseDeletedSubject("*", "*")
 		var err error
-		cdSub, err = processor.GetSubjectProcessor(ctx, eventSubject, rpProcessor.natsClient, rpProcessor.expenseDeleted)
+		edCCtx, err = processor.GetStreamProcessor(ctx, rpProcessor.natsClient, sourceStreamName, "EXPENSESPLITTER_EXPENSE_PROCESSOR_EXPENSE_DELETED", eventSubject, rpProcessor.expenseDeleted)
 		if err != nil {
 			return eris.Wrapf(err, "an error occurred processing subject %s", eventSubject)
 		}
 	}
-	var cuSub *nats.Subscription
+	var euCCtx jetstream.ConsumeContext
 	{
 		eventSubject := environment.GetExpenseUpdatedSubject("*", "*")
 		var err error
-		cuSub, err = processor.GetSubjectProcessor(ctx, eventSubject, rpProcessor.natsClient, rpProcessor.expenseUpdated)
+		euCCtx, err = processor.GetStreamProcessor(ctx, rpProcessor.natsClient, sourceStreamName, "EXPENSESPLITTER_EXPENSE_PROCESSOR_EXPENSE_UPDATED", eventSubject, rpProcessor.expenseUpdated)
 		if err != nil {
 			return eris.Wrapf(err, "an error occurred processing subject %s", eventSubject)
 		}
 	}
-	var gdSub *nats.Subscription
+	var gdCCtx jetstream.ConsumeContext
 	{
 		eventSubject := environment.GetGroupDeletedSubject("*")
 		var err error
-		gdSub, err = processor.GetSubjectProcessor(ctx, eventSubject, rpProcessor.natsClient, rpProcessor.groupDeleted)
+		gdCCtx, err = processor.GetStreamProcessor(ctx, rpProcessor.natsClient, groupSourceStreamName, "EXPENSESPLITTER_EXPENSE_PROCESSOR_GROUP_DELETED", eventSubject, rpProcessor.groupDeleted)
 		if err != nil {
 			return eris.Wrapf(err, "an error occurred processing subject %s", eventSubject)
 		}
 	}
-	var pdSub *nats.Subscription
+	var pdCCtx jetstream.ConsumeContext
 	{
 		eventSubject := environment.GetPersonDeletedSubject("*", "*")
 		var err error
-		pdSub, err = processor.GetSubjectProcessor(ctx, eventSubject, rpProcessor.natsClient, rpProcessor.personDeleted)
+		pdCCtx, err = processor.GetStreamProcessor(ctx, rpProcessor.natsClient, personSourceStreamName, "EXPENSESPLITTER_EXPENSE_PROCESSOR_PERSON_DELETED", eventSubject, rpProcessor.personDeleted)
 		if err != nil {
 			return eris.Wrapf(err, "an error occurred processing subject %s", eventSubject)
 		}
@@ -88,10 +102,6 @@ func (rpProcessor *expenseProcessor) Process(ctx context.Context) error {
 
 	<-ctx.Done()
 	log.Info("the context is done")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	if err := processor.UnsubscribeSubscriptions(ctx, ccSub, cdSub, cuSub, gdSub, pdSub); err != nil {
-		return eris.Wrap(err, "failed finalising expense processor")
-	}
+	processor.UnsubscribeConsumeContexts(ecCCtx, edCCtx, euCCtx, gdCCtx, pdCCtx)
 	return nil
 }

--- a/pkg/environment/variables.go
+++ b/pkg/environment/variables.go
@@ -123,6 +123,12 @@ func GetTraceCollectorPort(ctx context.Context) uint16 {
 	return MustLookupUint16(ctx, "TRACE_COLLECTOR_PORT")
 }
 
+// TODO: as env variable
+// GetExpenseSplitterSubject returns the name of the root subject all expense splitter events are published under
+func GetExpenseSplitterSubject() string {
+	return "expensesplitter"
+}
+
 // TODO: as env variable with %s parameter
 // GetGroupCreatedSubject returns the name of the subject events are published on when a group was created
 func GetGroupCreatedSubject(groupId string) string {
@@ -150,7 +156,11 @@ func GetGroupSubject(groupId string) string {
 // TODO: as env variable
 // GetGroupsSubject returns the name of the subject events of all groups are published on
 func GetGroupsSubject() string {
-	return "group"
+	return fmt.Sprintf("%s.group", GetExpenseSplitterSubject())
+}
+
+func GetGroupSourceStreamName() string {
+	return "EXPENSESPLITTER_GROUP"
 }
 
 // TODO: as env variable with %s parameter
@@ -183,6 +193,10 @@ func GetPeopleSubject(groupId string) string {
 	return fmt.Sprintf("%s.person", GetGroupSubject(groupId))
 }
 
+func GetPersonSourceStreamName() string {
+	return "EXPENSESPLITTER_PERSON"
+}
+
 // TODO: as env variable with %s parameter
 // GetCategoryCreatedSubject returns the name of the subject events are published on when a category was created
 func GetCategoryCreatedSubject(groupId string, categoryId string) string {
@@ -211,6 +225,10 @@ func GetCategorySubject(groupId string, categoryId string) string {
 // GetCategoriesSubject returns the name of the subject events of all categories are published on
 func GetCategoriesSubject(groupId string) string {
 	return fmt.Sprintf("%s.category", GetGroupSubject(groupId))
+}
+
+func GetCategorySourceStreamName() string {
+	return "EXPENSESPLITTER_CATEGORY"
 }
 
 // TODO: as env variable with %s parameter
@@ -243,6 +261,10 @@ func GetExpensesSubject(groupId string) string {
 	return fmt.Sprintf("%s.expense", GetGroupSubject(groupId))
 }
 
+func GetExpenseSourceStreamName() string {
+	return "EXPENSESPLITTER_EXPENSE"
+}
+
 // TODO: as env variable with %s parameter
 // GetExpenseStakeCreatedSubject returns the name of the subject events are published on when a expense stake was created
 func GetExpenseStakeCreatedSubject(groupId string, expenseId string, stakeId string) string {
@@ -273,6 +295,10 @@ func GetExpenseStakesSubject(groupId string, expenseId string) string {
 	return fmt.Sprintf("%s.expensestake", GetExpenseSubject(groupId, expenseId))
 }
 
+func GetExpenseStakeSourceStreamName() string {
+	return "EXPENSESPLITTER_EXPENSESTAKE"
+}
+
 // TODO: as env variable with %s parameter
 // GetCurrencyCreatedSubject returns the name of the subject events are published on when a group was created
 func GetCurrencyCreatedSubject(currencyId string) string {
@@ -300,7 +326,11 @@ func GetCurrencySubject(currencyId string) string {
 // TODO: as env variable
 // GetCurrenciesSubject returns the name of the subject events of all groups are published on
 func GetCurrenciesSubject() string {
-	return "group"
+	return fmt.Sprintf("%s.currency", GetExpenseSplitterSubject())
+}
+
+func GetCurrencySourceStreamName() string {
+	return "EXPENSESPLITTER_CURRENCY"
 }
 
 // TODO: as env variable

--- a/pkg/mq/processor/processor.go
+++ b/pkg/mq/processor/processor.go
@@ -2,53 +2,144 @@ package processor
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/nico151999/high-availability-expense-splitter/pkg/logging"
 	"github.com/rotisserie/eris"
-	"golang.org/x/sync/errgroup"
 
 	"google.golang.org/protobuf/proto"
 )
 
-func GetSubjectProcessor[E proto.Message](
+func CreateOrUpdateSourceStream(
 	ctx context.Context,
-	subjectName string,
-	natsClient *nats.EncodedConn,
+	natsClient *nats.Conn,
+	sourceStreamName string,
+	subject string,
+) (jetstream.Stream, error) {
+	log := logging.FromContext(ctx).With(
+		logging.String("sourceStream", sourceStreamName),
+		logging.String("subject", subject),
+	)
+
+	js, err := jetstream.New(natsClient)
+	if err != nil {
+		msg := "failed creating NATS jetstream client"
+		log.Error(msg, logging.Error(err))
+		return nil, eris.Wrap(err, msg)
+	}
+	stream, err := createOrUpdateStream(ctx, js, jetstream.StreamConfig{
+		Name:      sourceStreamName,
+		Subjects:  []string{subject},
+		Retention: jetstream.WorkQueuePolicy,
+		Discard:   jetstream.DiscardOld,
+		Storage:   jetstream.FileStorage,
+	})
+	if err != nil {
+		msg := "failed creating NATS jetstream source stream"
+		log.Error(msg, logging.Error(err))
+		return nil, eris.Wrap(err, msg)
+	}
+	return stream, nil
+}
+
+func GetStreamProcessor[E proto.Message](
+	ctx context.Context,
+	natsClient *nats.Conn,
+	sourceStreamName string,
+	streamAndConsumerName string,
+	subject string,
 	processor func(ctx context.Context, event E) error,
-) (*nats.Subscription, error) {
-	log := logging.FromContext(ctx).With(logging.String("subject", subjectName))
-	sub, err := natsClient.Subscribe(subjectName, func(msg E) {
-		// if err := msg.InProgress(); err != nil {
-		// 	log.Errorw("failed to inform NATS that a message is in progress", logging.Error(err))
-		// 	return
-		// }
+) (jetstream.ConsumeContext, error) {
+	log := logging.FromContext(ctx).With(
+		logging.String("sourceStream", sourceStreamName),
+		logging.String("stream", streamAndConsumerName),
+		logging.String("consumer", streamAndConsumerName),
+		logging.String("subject", subject),
+	)
+
+	js, err := jetstream.New(natsClient)
+	if err != nil {
+		msg := "failed creating NATS jetstream client"
+		log.Error(msg, logging.Error(err))
+		return nil, eris.Wrap(err, msg)
+	}
+	stream, err := createOrUpdateStream(ctx, js, jetstream.StreamConfig{
+		Name:      streamAndConsumerName,
+		Retention: jetstream.WorkQueuePolicy,
+		Discard:   jetstream.DiscardOld,
+		Storage:   jetstream.FileStorage,
+		Sources: []*jetstream.StreamSource{
+			{
+				Name:          sourceStreamName,
+				FilterSubject: subject,
+			},
+		},
+	})
+	if err != nil {
+		msg := "failed creating NATS jetstream stream"
+		log.Error(msg, logging.Error(err))
+		return nil, eris.Wrap(err, msg)
+	}
+	consumer, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+		Durable:       streamAndConsumerName,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		DeliverPolicy: jetstream.DeliverAllPolicy,
+		ReplayPolicy:  jetstream.ReplayInstantPolicy,
+	})
+	if err != nil {
+		msg := "failed creating NATS jetstream consumer"
+		log.Error(msg, logging.Error(err))
+		return nil, eris.Wrap(err, msg)
+	}
+
+	consCtx, err := consumer.Consume(func(msg jetstream.Msg) {
+		if err := msg.InProgress(); err != nil {
+			log.Error("failed to inform NATS that a message is in progress", logging.Error(err))
+			return
+		}
+
+		var event E
+		event = reflect.New(reflect.TypeOf(event).Elem()).Interface().(E)
+		if err := proto.Unmarshal(msg.Data(), event); err != nil {
+			log.Error("failed to unmarshal data of a message", logging.Error(err))
+			return
+		}
+
 		log.Debug("processing event")
-		if err := processor(ctx, msg); err != nil {
+		if err := processor(ctx, event); err != nil {
 			log.Error("failed to process a message", logging.Error(err))
 			return
 		}
-		// if err := msg.Ack(); err != nil {
-		// 	log.Errorw("failed to acknowledge a message", logging.Error(err))
-		// 	return
-		// }
+
+		if err := msg.Ack(); err != nil {
+			log.Error("failed to acknowledge a message", logging.Error(err))
+			return
+		}
 	})
 	if err != nil {
-		return nil, eris.Wrapf(err, "failed to subscribe to NATS stream subject '%s'", subjectName)
+		return nil, eris.Wrapf(err, "failed to subscribe to NATS stream subject '%s'", subject)
 	}
-	return sub, nil
+
+	return consCtx, nil
 }
 
-func UnsubscribeSubscriptions(ctx context.Context, subs ...*nats.Subscription) error {
-	errGr, _ := errgroup.WithContext(ctx)
-	for _, sub := range subs {
-		s := sub
-		errGr.Go(func() error {
-			if err := s.Unsubscribe(); err != nil {
-				return eris.Wrapf(err, "failed to unsubscribe subscription on %s event", s.Subject)
-			}
-			return nil
-		})
+func UnsubscribeConsumeContexts(cctxs ...jetstream.ConsumeContext) {
+	for _, cctx := range cctxs {
+		cctx.Stop()
 	}
-	return errGr.Wait()
+}
+
+// createOrUpdateStream creates a stream if it does not exist or updates it otherwise
+// TODO: remove this function once this is merged: https://github.com/nats-io/nats.go/pull/1395
+func createOrUpdateStream(ctx context.Context, js jetstream.JetStream, cfg jetstream.StreamConfig) (jetstream.Stream, error) {
+	s, err := js.UpdateStream(ctx, cfg)
+	if err != nil {
+		if !eris.Is(err, jetstream.ErrStreamNotFound) {
+			return nil, err
+		}
+		return js.CreateStream(ctx, cfg)
+	}
+	return s, nil
 }


### PR DESCRIPTION
This ensures events are only processed once by the processors while also ensuring that they are processed at all. The key is the creation of a stream per subject which serves as a source stream for further streams. This way, multiple work queues on the same subject become possible. This is necessary since we need work queues for the same resource type that are processed by different processors while ensuring each processor type processes the event exactly once.